### PR TITLE
Replace python-jose with pyjwt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,11 @@ dependencies = [
     # Security (⚠️ SECURITY REVIEW NEEDED BEFORE PRODUCTION ⚠️)
     # TODO: python-jose has known CVEs (CVE-2024-33664, CVE-2024-33663) - no fixes available
     # Alternative: pyjwt + cryptography (more secure, actively maintained)
-    "python-jose[cryptography]>=3.3.0",  # VULNERABLE - replace with pyjwt before production
+    "pyjwt>=2.8.0",                    # Secure JWT library (maintained)
+    "cryptography>=41.0.0",            # Modern crypto primitives
     "passlib[bcrypt]>=1.7.0",
     "python-multipart>=0.0.6",
 
-    # 🔐 FUTURE: Modern JWT alternatives for production:
-    # "pyjwt>=2.8.0",                    # Secure JWT library (maintained)
-    # "cryptography>=41.0.0",            # Modern crypto primitives
-    # "python-jose[cryptography]>=3.3.0",  # REMOVE before production
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- swap insecure `python-jose` dependency for `pyjwt` + `cryptography`

## Testing
- `make quality` *(fails: ruff lint errors)*
- `make type-check` *(fails: mypy missing stubs and typing issues)*
- `make test-fast` *(fails: unknown pytest config option)*

------
https://chatgpt.com/codex/tasks/task_e_687972ed4bb0832c9e2dd6fc95eac08c