### PR TITLE
Implement label deletion safety check

### DIFF
--- a/src/big_mood_detector/application/services/label_service.py
+++ b/src/big_mood_detector/application/services/label_service.py
@@ -1,10 +1,9 @@
-"""
-Label service for managing mood and health labels.
+"""Label service for managing mood and health labels.
 
 This service orchestrates label operations following Clean Architecture principles.
 """
 
-from typing import List, Optional
+from typing import Any
 from uuid import uuid4
 
 from big_mood_detector.domain.entities.label import Label
@@ -13,32 +12,41 @@ from big_mood_detector.domain.repositories.label_repository import LabelReposito
 
 class LabelService:
     """Service for managing labels."""
-    
-    def __init__(self, label_repository: LabelRepository):
-        """Initialize the label service with a repository."""
+
+    def __init__(
+        self,
+        label_repository: LabelRepository,
+        dependent_repositories: list[Any] | None = None,
+    ) -> None:
+        """Initialize the label service with a repository.
+
+        Args:
+            label_repository: Repository used for CRUD on labels.
+            dependent_repositories: Repositories that may reference labels.
+        """
         self.repository = label_repository
-    
+        self.dependent_repositories = dependent_repositories or []
+
     def create_label(
         self,
         name: str,
         description: str,
         category: str,
         color: str,
-        metadata: Optional[dict] = None
+        metadata: dict | None = None,
     ) -> Label:
-        """
-        Create a new label.
-        
+        """Create a new label.
+
         Args:
             name: Label name (must be unique)
             description: Label description
             category: Label category (e.g., mood, sleep, activity)
             color: Label color in hex format
             metadata: Optional metadata dictionary
-            
+
         Returns:
             Created label
-            
+
         Raises:
             ValueError: If label with same name already exists
         """
@@ -46,7 +54,7 @@ class LabelService:
         existing_labels = self.repository.find_by_name(name)
         if existing_labels:
             raise ValueError(f"Label with name '{name}' already exists")
-        
+
         # Create new label
         label = Label(
             id=f"label-{uuid4().hex[:8]}",
@@ -54,72 +62,71 @@ class LabelService:
             description=description,
             category=category,
             color=color,
-            metadata=metadata or {}
+            metadata=metadata or {},
         )
-        
+
         # Save to repository
         self.repository.save(label)
-        
+
         return label
-    
-    def get_label(self, label_id: str) -> Optional[Label]:
+
+    def get_label(self, label_id: str) -> Label | None:
         """Get a label by ID."""
         return self.repository.find_by_id(label_id)
-    
-    def list_labels(self, category: Optional[str] = None) -> List[Label]:
-        """
-        List all labels, optionally filtered by category.
-        
+
+    def list_labels(self, category: str | None = None) -> list[Label]:
+        """List all labels, optionally filtered by category.
+
         Args:
             category: Optional category filter
-            
+
         Returns:
             List of labels
         """
         if category:
             return self.repository.find_by_category(category)
         return self.repository.find_all()
-    
-    def search_labels(self, query: str, limit: int = 10) -> List[Label]:
-        """
-        Search labels by name or description.
-        
+
+    def search_labels(self, query: str, limit: int = 10) -> list[Label]:
+        """Search labels by name or description.
+
         Args:
             query: Search query
             limit: Maximum number of results
-            
+
         Returns:
             List of matching labels
         """
         all_labels = self.repository.find_all()
-        
+
         # Simple search implementation
         # In production, this would use a proper search index
         query_lower = query.lower()
         matches = []
-        
+
         for label in all_labels:
-            if (query_lower in label.name.lower() or 
-                query_lower in label.description.lower()):
+            if (
+                query_lower in label.name.lower()
+                or query_lower in label.description.lower()
+            ):
                 matches.append(label)
-                
+
                 if len(matches) >= limit:
                     break
-        
+
         return matches
-    
+
     def update_label(
         self,
         label_id: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        category: Optional[str] = None,
-        color: Optional[str] = None,
-        metadata: Optional[dict] = None
+        name: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        color: str | None = None,
+        metadata: dict | None = None,
     ) -> Label:
-        """
-        Update an existing label.
-        
+        """Update an existing label.
+
         Args:
             label_id: ID of label to update
             name: New name (optional)
@@ -127,23 +134,23 @@ class LabelService:
             category: New category (optional)
             color: New color (optional)
             metadata: New metadata (optional)
-            
+
         Returns:
             Updated label
-            
+
         Raises:
             ValueError: If label not found
         """
         label = self.repository.find_by_id(label_id)
         if not label:
             raise ValueError(f"Label with ID '{label_id}' not found")
-        
+
         # Check name uniqueness if changing name
         if name and name != label.name:
             existing = self.repository.find_by_name(name)
             if existing:
                 raise ValueError(f"Label with name '{name}' already exists")
-        
+
         # Create updated label
         updated_label = Label(
             id=label.id,
@@ -151,33 +158,47 @@ class LabelService:
             description=description or label.description,
             category=category or label.category,
             color=color or label.color,
-            metadata=metadata if metadata is not None else label.metadata
+            metadata=metadata if metadata is not None else label.metadata,
         )
-        
+
         # Save updated label
         self.repository.save(updated_label)
-        
+
         return updated_label
-    
+
     def delete_label(self, label_id: str) -> bool:
-        """
-        Delete a label.
-        
+        """Delete a label.
+
         Args:
             label_id: ID of label to delete
-            
+
         Returns:
             True if deleted, False if not found
-            
+
         Raises:
             ValueError: If label is in use (future implementation)
         """
         label = self.repository.find_by_id(label_id)
         if not label:
             return False
-        
-        # TODO: Check if label is in use by any records
-        # This would involve checking with other repositories
-        
+
+        # Check if the label is referenced by other repositories
+        for repo in self.dependent_repositories:
+            if hasattr(repo, "find_by_label_id"):
+                references = repo.find_by_label_id(label_id)
+            elif hasattr(repo, "find_by_label"):
+                references = repo.find_by_label(label_id)
+            elif hasattr(repo, "label_in_use"):
+                references = repo.label_in_use(label_id)
+            else:
+                # Repository does not provide a way to check label usage
+                continue
+
+            # Interpret truthy return values as evidence of usage
+            if references:
+                raise ValueError(
+                    f"Label '{label.name}' is referenced by existing records"
+                )
+
         self.repository.delete(label_id)
         return True

--- a/src/big_mood_detector/domain/entities/label.py
+++ b/src/big_mood_detector/domain/entities/label.py
@@ -6,14 +6,14 @@ to analyzed health data (e.g., "Depression", "Mania", "Sleep Disruption").
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, Any
+from typing import Any
 
 
 @dataclass(frozen=True)
 class Label:
     """
     Represents a label for categorizing mood and health states.
-    
+
     Attributes:
         id: Unique identifier for the label
         name: Human-readable name (e.g., "Depression", "Mania")
@@ -22,29 +22,29 @@ class Label:
         category: Category grouping (e.g., "mood", "sleep", "activity")
         metadata: Additional metadata (e.g., DSM-5 codes, thresholds)
     """
-    
+
     id: str
     name: str
     description: str
     color: str
     category: str
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    
-    def __post_init__(self):
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
         """Validate label data after initialization."""
         if not self.name:
             raise ValueError("Label name cannot be empty")
-        
+
         if not self.description:
             raise ValueError("Label description cannot be empty")
-        
+
         if not self.category:
             raise ValueError("Label category cannot be empty")
-        
+
         # Validate color format (basic hex validation)
         if not self.color or not self.color.startswith("#"):
             raise ValueError("Label color must be in hex format (e.g., #FF0000)")
-        
+
         # Validate hex color length
         if len(self.color) not in [4, 7]:  # #RGB or #RRGGBB
             raise ValueError("Invalid hex color format")


### PR DESCRIPTION
## Summary
- check dependent repos before deleting labels
- improve docs & typing in `LabelService`
- add missing type hint to `Label.__post_init__`
- cover delete failure case in CLI tests

## Testing
- `pre-commit run --files src/big_mood_detector/application/services/label_service.py tests/unit/interfaces/cli/test_label_commands.py` *(fails: bandit, detect-secrets)*
- `pytest tests/unit/interfaces/cli/test_label_commands.py -k test_delete_label_in_use` *(fails: ImportError: TensorFlow is required)*

------
https://chatgpt.com/codex/tasks/task_e_687972e6e4fc832ca4fa58e3a14573b5